### PR TITLE
Fixed mount total selector

### DIFF
--- a/profile/mount.json
+++ b/profile/mount.json
@@ -13,6 +13,6 @@
         }
     },
     "TOTAL": {
-        "selector": ".mount__sort__total > span:nth-child(1)"
+        "selector": ".minion__sort__total > span:nth-child(1)"
     }
 }


### PR DESCRIPTION
As of right now, the CSS class of the **mount** total in the lodestone is, possibly by error, **minion**__sort__total.

E.g.:
![Unbenannt](https://user-images.githubusercontent.com/17272774/140648002-07b227f5-d370-461c-b279-0d6ce3694946.PNG)
@ https://na.finalfantasyxiv.com/lodestone/character/24250186/mount

Therefore with the current mount profile you don't get the mount total in your parsed output.
This PR fixes the mount total selector.