### PR TITLE
Fix SERVER selector regex to look for square brackets

### DIFF
--- a/profile/character.json
+++ b/profile/character.json
@@ -95,7 +95,7 @@
     },
     "SERVER": {
         "selector": "p.frame__chara__world:last-of-type",
-        "regex": "(?P<World>\\w*)\\s+\\((?P<DC>\\w*)\\)"
+        "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
     },
     "TITLE": {
         "selector": ".frame__chara__title"


### PR DESCRIPTION
Fixes https://github.com/xivapi/lodestone-css-selectors/issues/15