### PR TITLE
Selector fix for when FC Community finder element is present

### DIFF
--- a/freecompany/freecompany.json
+++ b/freecompany/freecompany.json
@@ -1,10 +1,10 @@
 {
     "ACTIVE_STATE": {
-        "selector": "p.freecompany__text:nth-child(3)",
+        "selector": "p.freecompany__text:nth-of-type(1)",
         "regex": "\\s*(?P<ActiveState>\\S+\\s?\\S*)"
     },
     "ACTIVE_MEMBER_COUNT": {
-        "selector": "p.freecompany__text:nth-child(12)"
+        "selector": "p.freecompany__text:nth-of-type(6)"
     },
     "CREST_LAYERS": {
         "BOTTOM": {
@@ -23,7 +23,7 @@
     "ESTATE": {
         "NO_ESTATE": {
             "selector": ".freecompany__estate__none"
-        },  
+        },
         "GREETING": {
             "selector": ".freecompany__estate__greeting"
         },
@@ -35,7 +35,7 @@
         }
     },
     "FORMED": {
-        "selector": "p.freecompany__text:nth-child(10) > script",
+        "selector": "p.freecompany__text:nth-of-type(5) > script",
         "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)"
     },
     "GRAND_COMPANY": {
@@ -51,7 +51,7 @@
         "selector": ".freecompany__text__name"
     },
     "RANK": {
-        "selector": "p.freecompany__text:nth-child(14)"
+        "selector": "p.freecompany__text:nth-of-type(7)"
     },
     "RANKING": {
         "WEEKLY": {


### PR DESCRIPTION
Some selectors for Free Company pages are broken when the company is using the Community Finder page, as an extra element is added to the page which pushes `p.freecompany__text:nth-child(n)` offsets.

![image](https://user-images.githubusercontent.com/11656396/177164493-c61eaeff-2f0d-4efe-b51b-1dac8b9ceceb.png)

Using `p.freecompany__text:nth-of-type(1)` instead, seems to combat the issue from my testing in cases where the community finder element exists or not.