### PR TITLE
Fix materia selector for dyed items

### DIFF
--- a/profile/gearset.json
+++ b/profile/gearset.json
@@ -16,23 +16,23 @@
             "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -56,23 +56,23 @@
             "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -96,23 +96,23 @@
             "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -136,23 +136,23 @@
             "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -176,23 +176,23 @@
             "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -216,23 +216,23 @@
             "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -256,23 +256,23 @@
             "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -296,23 +296,23 @@
             "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -336,23 +336,23 @@
             "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -376,23 +376,23 @@
             "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -416,23 +416,23 @@
             "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -456,23 +456,23 @@
             "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {
@@ -496,23 +496,23 @@
             "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1)"
         },
         "MATERIA_1": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(1) > div:nth-child(2)",
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_2": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(2) > div:nth-child(2)",
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_3": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(3) > div:nth-child(2)",
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_4": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(4) > div:nth-child(2)",
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "MATERIA_5": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-child(7) > li:nth-child(5) > div:nth-child(2)",
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
             "regex": "(?P<Name>.*)<br/>"
         },
         "CREATOR_NAME": {


### PR DESCRIPTION
These changes are based on @ge7nic's work with [NetStone](https://github.com/xivapi/NetStone) (see our [fork](https://github.com/Koenari/NetStone)) who discovered that it is not the 7th entry on dyed items.
I have tested these changes with NetStone. I cannot test for other libraries unfortunately.