### PR TITLE
Fix Free Company icon layer selectors

### DIFF
--- a/profile/character.json
+++ b/profile/character.json
@@ -36,11 +36,11 @@
                 "attribute": "src"
             },
             "MIDDLE": {
-                "selector": "div.character__freecompany__crest > div > img:nth-child(1)",
+                "selector": "div.character__freecompany__crest > div > img:nth-child(2)",
                 "attribute": "src"
             },
             "TOP": {
-                "selector": "div.character__freecompany__crest > div > img:nth-child(1)",
+                "selector": "div.character__freecompany__crest > div > img:nth-child(3)",
                 "attribute": "src"
             }
         }


### PR DESCRIPTION
The current Free Company image layer selectors incorrectly all reference the bottom layer. This PR fixes the selectors so that the middle and top layers are correctly selected.