### PR TITLE
Parse Free Company name from character page

### DIFF
--- a/profile/character.json
+++ b/profile/character.json
@@ -25,10 +25,13 @@
         }
     },
     "FREE_COMPANY": {
-        "NAME": {
+        "ID": {
             "selector": ".character__freecompany__name > h4:nth-child(2) > a:nth-child(1)",
             "attribute": "href",
             "regex": "/lodestone/freecompany/(?P<ID>.+)/"
+        },
+        "NAME": {
+            "selector": ".character__freecompany__name > h4:nth-child(2) > a:nth-child(1)"
         },
         "ICON_LAYERS": {
             "BOTTOM": {


### PR DESCRIPTION
Currently, when parsing the character page, the Free Company ID is parsed but the Free Company name isn't, even though it's available on the same page. This PR adds a `Name` property to the `FreeCompany` object for parsed character profiles.

This saves you an extra HTTP request when you're interested in the name of a character's Free Company, but none of its other details.