### PR TITLE
FIx selectors for FCs recruiting on the lodestone

### DIFF
--- a/freecompany/freecompany.json
+++ b/freecompany/freecompany.json
@@ -64,7 +64,7 @@
         }
     },
     "RECRUITMENT": {
-        "selector": "p.freecompany__text:nth-child(5)",
+        "selector": "p.freecompany__text:nth-child(5):not(.freecompany__text__message)",
         "regex": "\\s*(?P<ActiveState>\\S*)"
     },
     "SERVER": {

--- a/freecompany/reputation.json
+++ b/freecompany/reputation.json
@@ -1,41 +1,41 @@
 {
     "MAELSTROM": {
         "NAME": {
-            "selector": "div.freecompany__reputation:nth-child(16) > div:nth-child(2) > p:nth-child(1)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(3) > div:nth-child(2) > p:nth-child(1)"
         },
         "PROGRESS": {
-            "selector": "div.freecompany__reputation:nth-child(16) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
+            "selector": "div.freecompany__reputation:nth-last-of-type(3) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
             "attribute": "style",
             "regex": "width:(?P<Progress>\\d+)%;"
         },
         "RANK": {
-            "selector": "div.freecompany__reputation:nth-child(16) > div:nth-child(2) > p:nth-child(2)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(3) > div:nth-child(2) > p:nth-child(2)"
         }
     },
     "ADDERS": {
         "NAME": {
-            "selector": "div.freecompany__reputation:nth-child(17) > div:nth-child(2) > p:nth-child(1)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(2) > div:nth-child(2) > p:nth-child(1)"
         },
         "PROGRESS": {
-            "selector": "div.freecompany__reputation:nth-child(17) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
+            "selector": "div.freecompany__reputation:nth-last-of-type(2) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
             "attribute": "style",
             "regex": "width:(?P<Progress>\\d+)%;"
         },
         "RANK": {
-            "selector": "div.freecompany__reputation:nth-child(17) > div:nth-child(2) > p:nth-child(2)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(2) > div:nth-child(2) > p:nth-child(2)"
         }
     },
     "FLAMES": {
         "NAME": {
-            "selector": "div.freecompany__reputation:nth-child(18) > div:nth-child(2) > p:nth-child(1)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(1) > div:nth-child(2) > p:nth-child(1)"
         },
         "PROGRESS": {
-            "selector": "div.freecompany__reputation:nth-child(18) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
+            "selector": "div.freecompany__reputation:nth-last-of-type(1) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
             "attribute": "style",
             "regex": "width:(?P<Progress>\\d+)%;"
         },
         "RANK": {
-            "selector": "div.freecompany__reputation:nth-child(18) > div:nth-child(2) > p:nth-child(2)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(1) > div:nth-child(2) > p:nth-child(2)"
         }
     }
 }


### PR DESCRIPTION
As reported by https://github.com/xivapi/NetStone/issues/19 the recruiting banner breaks a few selectors
These changes are tested in NetStone for both FCs with and without the banner