### PR TITLE
Fix Crossworld Linkshell search

### DIFF
--- a/search/cwls.json
+++ b/search/cwls.json
@@ -23,7 +23,7 @@
         }
     },
     "PAGE_INFO": {
-        "selector": "ul.btn__pager:nth-child(6) > li:nth-child(3)",
+        "selector": "ul.btn__pager > li:nth-child(3)",
         "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
     },
     "LIST_NEXT_BUTTON": {


### PR DESCRIPTION
Current selector did fail yesterday, but seems to work today. There seems to be some aaditional conditions.
Would probably be a good idea to unifiy selectors `PAGE_INFO` and `LIST_NEXT_BUTTON` for searches. There seems to be a wild mix of `ul.btn__pager` and `ul.btn__pager:nth-child(6)` used for the same element