### PR TITLE
Fix CWLS Name pattern to handle name with spaces

### DIFF
--- a/cwls/cwls.json
+++ b/cwls/cwls.json
@@ -1,7 +1,7 @@
 {
     "NAME": {
         "selector": ".heading__linkshell__name",
-        "regex": "\\s*(?P<Name>\\S*)"
+        "regex": "\\s*(?P<Name>.+)"
     },
     "DC": {
         "selector": ".heading__cwls__dcname"


### PR DESCRIPTION
Previous pattern would only return the first word of the name and `break` on the first blank space character after the first non-blank space character.

Example Before:
![image](https://github.com/user-attachments/assets/213532a1-b7b9-42d0-96bb-b3b96bee0080)

Example After:
![image](https://github.com/user-attachments/assets/97eb19c4-3146-4031-9177-3f9ff86f1e30)
