### PR TITLE
Add types to everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All selectors are accompanied by a `type` field, which specifies what the expect
 | --------- | ------------------------------------------------------------------------------------- |
 | `integer` | The type is an integer                                                                |
 | `string`  | The type is a string                                                                  |
-| `boolean` | The type is expected to be 'true' if the selector returns a result; `false` otherwise |
+| `boolean` | The type is expected to be `true` if the selector returns a result; `false` otherwise |
 
 There are two formats for type:
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,34 @@ injected into the page with AJAX, and separate requests need to be made to get e
 ### Achievements (`profile/achievements.json`)
 Achievements are on the `/achievement` endpoint. Use the list selector to get the list of achievements on the page, and then get their IDs from the `href` attribute
 of the link. Use the next button's selector to request the next page and scrape the next set of achievements until the href is `javascript:void(0);`.
+
+## Types
+
+All selectors are accompanied by a `type` field, which specifies what the expected type is for the field. At current, only the following types are used:
+
+| Name      | Description                                                                           |
+| --------- | ------------------------------------------------------------------------------------- |
+| `integer` | The type is an integer                                                                |
+| `string`  | The type is a string                                                                  |
+| `boolean` | The type is expected to be 'true' if the selector returns a result; `false` otherwise |
+
+There are two formats for type:
+
+* Common form - the selector is of this type
+
+```json
+{
+    "type": "integer"
+}
+```
+
+* Multiple value form - the selector results in multiple named values; this is only used with regex selectors that have named groups
+
+```json
+{
+    "type": {
+        "Server": "string",
+        "DC": "string"
+    }
+}
+```

--- a/cwls/cwls.json
+++ b/cwls/cwls.json
@@ -1,9 +1,11 @@
 {
     "NAME": {
         "selector": ".heading__linkshell__name",
-        "regex": "\\s*(?P<Name>.+)"
+        "regex": "\\s*(?P<Name>.+)",
+        "type": "string"
     },
     "DC": {
-        "selector": ".heading__cwls__dcname"
+        "selector": ".heading__cwls__dcname",
+        "type": "string"
     }
 }

--- a/cwls/members.json
+++ b/cwls/members.json
@@ -9,43 +9,59 @@
         },
         "AVATAR": {
             "selector": ".entry__chara__face img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "ID": {
             "selector": ".entry__link",
             "attribute": "href",
-            "regex": "/lodestone/character/(?P<ID>\\d*)/"
+            "regex": "/lodestone/character/(?P<ID>\\d*)/",
+            "type": "string"
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "RANK": {
             "selector": ".entry__chara_info > .js__tooltip",
             "attribute": "data-tooltip",
-            "regex": "/ (?P<RankName>.+)"
+            "regex": "/ (?P<RankName>.+)",
+            "type": "string"
         },
         "RANK_ICON": {
             "selector": ".entry__chara_info > .js__tooltip > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "LINKSHELL_RANK": {
-            "selector": ".entry__chara_info__linkshell > span"
+            "selector": ".entry__chara_info__linkshell > span",
+            "type": "string"
         },
         "LINKSHELL_RANK_ICON": {
             "selector": ".entry__chara_info__linkshell > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "SERVER": {
             "selector": ".entry__world",
-            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+            "type": {
+              "World": "string",
+              "DC": "string"
+            }
         }
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager:nth-child(5) > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager:nth-child(5) > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "integer"
     }
 }

--- a/freecompany/focus.json
+++ b/freecompany/focus.json
@@ -1,131 +1,177 @@
 {
     "NOT_SPECIFIED": {
-        "selector": "p.freecompany__text:nth-child(7)"
+        "selector": "p.freecompany__text:nth-child(7)",
+        "type": "string"
     },
     "RP": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(1) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(1) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(1) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(1)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     },
     "LEVELING": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(2) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(2) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(2) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(2)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     },
     "CASUAL": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(3) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(3) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(3)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     },
     "HARDCORE": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(4) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(4) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(4) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(4)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     },
     "DUNGEONS": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(5) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(5) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(5) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(5)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     },
     "GUILDHESTS": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(6) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(6) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(6) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(6)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     },
     "TRIALS": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(7) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(7) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(7) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(7)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     },
     "RAIDS": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(8) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(8) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(8) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(8)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     },
     "PVP": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(9) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(9) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(9) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(7) > li:nth-child(9)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         }
     }
 }

--- a/freecompany/freecompany.json
+++ b/freecompany/freecompany.json
@@ -1,80 +1,114 @@
 {
     "ACTIVE_STATE": {
         "selector": "p.freecompany__text:nth-of-type(1):not(.freecompany__text__message)",
-        "regex": "\\s*(?P<ActiveState>\\S+\\s?\\S*)"
+        "regex": "\\s*(?P<ActiveState>\\S+\\s?\\S*)",
+        "type": {
+          "ActiveState": "string"
+        }
     },
     "ACTIVE_MEMBER_COUNT": {
-        "selector": "p.freecompany__text:nth-of-type(6)"
+        "selector": "p.freecompany__text:nth-of-type(6)",
+        "type": "integer"
     },
     "CREST_LAYERS": {
         "BOTTOM": {
             "selector": "div.ldst__window:nth-child(1) > div:nth-child(2) > a:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "MIDDLE": {
             "selector": "div.ldst__window:nth-child(1) > div:nth-child(2) > a:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > img:nth-child(2)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "TOP": {
             "selector": "div.ldst__window:nth-child(1) > div:nth-child(2) > a:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > img:nth-child(3)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     },
     "ESTATE": {
         "NO_ESTATE": {
-            "selector": ".freecompany__estate__none"
+            "selector": ".freecompany__estate__none",
+            "type": "boolean"
         },
         "GREETING": {
-            "selector": ".freecompany__estate__greeting"
+            "selector": ".freecompany__estate__greeting",
+            "type": "string"
         },
         "NAME": {
-            "selector": ".freecompany__estate__name"
+            "selector": ".freecompany__estate__name",
+            "type": "string"
         },
         "PLOT": {
-            "selector": ".freecompany__estate__text"
+            "selector": ".freecompany__estate__text",
+            "type": "string"
         }
     },
     "FORMED": {
         "selector": "p.freecompany__text:nth-of-type(5) > script",
-        "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)"
+        "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)",
+        "type": {
+          "Timestamp": "integer"
+        }
     },
     "GRAND_COMPANY": {
         "selector": "div.ldst__window:nth-child(1) > div:nth-child(2) > a:nth-child(1) > div:nth-child(2) > p:nth-child(1)",
-        "regex": "(?P<Name>\\w.*)<(?P<Rank>\\w*)>"
+        "regex": "(?P<Name>\\w.*)<(?P<Rank>\\w*)>",
+        "type": {
+          "Name": "string",
+          "Rank": "string"
+        }
     },
     "ID": {
         "selector": "div.ldst__window:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
         "attribute": "href",
-        "regex": "/lodestone/freecompany/(?P<ID>\\d*)/"
+        "regex": "/lodestone/freecompany/(?P<ID>\\d*)/",
+        "type": {
+          "ID": "integer"
+        }
     },
     "NAME": {
-        "selector": ".freecompany__text__name"
+        "selector": ".freecompany__text__name",
+        "type": "string"
     },
     "RANK": {
-        "selector": "p.freecompany__text:nth-of-type(7)"
+        "selector": "p.freecompany__text:nth-of-type(7)",
+        "type": "string"
     },
     "RANKING": {
         "WEEKLY": {
             "selector": ".character__ranking__data tr:nth-child(1) > th:nth-child(1)",
-            "regex": "Weekly Rank:(?P<Rank>.+) \\(previous week\\)"
+            "regex": "Weekly Rank:(?P<Rank>.+) \\(previous week\\)",
+            "type": "integer"
         },
         "MONTHLY": {
             "selector": ".character__ranking__data tr:nth-child(2) > th:nth-child(1)",
-            "regex": "Monthly Rank:(?P<Rank>.*) \\(previous month\\)"
+            "regex": "Monthly Rank:(?P<Rank>.*) \\(previous month\\)",
+            "type": "integer"
         }
     },
     "RECRUITMENT": {
         "selector": "p.freecompany__text:nth-child(5):not(.freecompany__text__message)",
-        "regex": "\\s*(?P<ActiveState>\\S*)"
+        "regex": "\\s*(?P<ActiveState>\\S*)",
+        "type": {
+          "ActiveState": "string"
+        }
     },
     "SERVER": {
         "selector": "div.ldst__window:nth-child(1) > div:nth-child(2) > a:nth-child(1) > div:nth-child(2) > p:nth-child(3)",
-        "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+        "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+        "type": {
+          "World": "string",
+          "DC": "string"
+        }
     },
     "SLOGAN": {
-        "selector": ".freecompany__text__message"
+        "selector": ".freecompany__text__message",
+        "type": "string"
     },
     "TAG": {
-        "selector": ".freecompany__text.freecompany__text__tag"
+        "selector": ".freecompany__text.freecompany__text__tag",
+        "type": "string"
     }
 }

--- a/freecompany/members.json
+++ b/freecompany/members.json
@@ -9,43 +9,63 @@
         },
         "AVATAR": {
             "selector": ".entry__chara__face > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "ID": {
             "selector": ".entry__bg",
             "attribute": "href",
-            "regex": "/lodestone/character/(?P<ID>\\d*)/"
+            "regex": "/lodestone/character/(?P<ID>\\d*)/",
+            "type": {
+              "ID": "integer"
+            }
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "FC_RANK": {
-            "selector": ".entry__freecompany__info > li:nth-child(1) > span"
+            "selector": ".entry__freecompany__info > li:nth-child(1) > span",
+            "type": "string"
         },
         "FC_RANK_ICON": {
             "selector": ".entry__freecompany__info > li:nth-child(1) > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "RANK": {
             "selector": ".entry__freecompany__info > .js__tooltip",
             "attribute": "data-tooltip",
-            "regex": "/ (?P<RankName>.+)"
+            "regex": "/ (?P<RankName>.+)",
+            "type": {
+              "RankName": "string"
+            }
         },
         "RANK_ICON": {
             "selector": ".entry__freecompany__info > .js__tooltip > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "SERVER": {
             "selector": ".entry__world",
-            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+            "type": {
+              "World": "string",
+              "DC": "string"
+            }
         }
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager:nth-child(4) > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager:nth-child(4) > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "string"
     }
 }

--- a/freecompany/reputation.json
+++ b/freecompany/reputation.json
@@ -1,41 +1,56 @@
 {
     "MAELSTROM": {
         "NAME": {
-            "selector": "div.freecompany__reputation:nth-last-of-type(3) > div:nth-child(2) > p:nth-child(1)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(3) > div:nth-child(2) > p:nth-child(1)",
+            "type": "string"
         },
         "PROGRESS": {
             "selector": "div.freecompany__reputation:nth-last-of-type(3) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
             "attribute": "style",
-            "regex": "width:(?P<Progress>\\d+)%;"
+            "regex": "width:(?P<Progress>\\d+)%;",
+            "type": {
+              "Progress": "integer"
+            }
         },
         "RANK": {
-            "selector": "div.freecompany__reputation:nth-last-of-type(3) > div:nth-child(2) > p:nth-child(2)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(3) > div:nth-child(2) > p:nth-child(2)",
+            "type": "string"
         }
     },
     "ADDERS": {
         "NAME": {
-            "selector": "div.freecompany__reputation:nth-last-of-type(2) > div:nth-child(2) > p:nth-child(1)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(2) > div:nth-child(2) > p:nth-child(1)",
+            "type": "string"
         },
         "PROGRESS": {
             "selector": "div.freecompany__reputation:nth-last-of-type(2) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
             "attribute": "style",
-            "regex": "width:(?P<Progress>\\d+)%;"
+            "regex": "width:(?P<Progress>\\d+)%;",
+            "type": {
+              "Progress": "integer"
+            }
         },
         "RANK": {
-            "selector": "div.freecompany__reputation:nth-last-of-type(2) > div:nth-child(2) > p:nth-child(2)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(2) > div:nth-child(2) > p:nth-child(2)",
+            "type": "string"
         }
     },
     "FLAMES": {
         "NAME": {
-            "selector": "div.freecompany__reputation:nth-last-of-type(1) > div:nth-child(2) > p:nth-child(1)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(1) > div:nth-child(2) > p:nth-child(1)",
+            "type": "string"
         },
         "PROGRESS": {
             "selector": "div.freecompany__reputation:nth-last-of-type(1) > div:nth-child(2) > div:nth-child(3) > div:nth-child(1)",
             "attribute": "style",
-            "regex": "width:(?P<Progress>\\d+)%;"
+            "regex": "width:(?P<Progress>\\d+)%;",
+            "type": {
+              "Progress": "integer"
+            }
         },
         "RANK": {
-            "selector": "div.freecompany__reputation:nth-last-of-type(1) > div:nth-child(2) > p:nth-child(2)"
+            "selector": "div.freecompany__reputation:nth-last-of-type(1) > div:nth-child(2) > p:nth-child(2)",
+            "type": "string"
         }
     }
 }

--- a/freecompany/seeking.json
+++ b/freecompany/seeking.json
@@ -4,72 +4,97 @@
     },
     "TANK": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(1) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(1) > p:nth-child(2)",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(1)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(1) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     },
     "HEALER": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(2) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(2) > p:nth-child(2)",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(2)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(2) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     },
     "DPS": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(3) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(3)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(3) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     },
     "CRAFTER": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(4) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(4) > p:nth-child(2)",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(4)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(4) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     },
     "GATHERER": {
         "NAME": {
-            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(5) > p:nth-child(2)"
+            "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(5) > p:nth-child(2)",
+            "type": "string"
         },
         "STATUS": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(5)",
             "attribute": "class",
-            "regex": "freecompany__focus_icon--(?P<Status>off)"
+            "regex": "freecompany__focus_icon--(?P<Status>off)",
+            "type": {
+              "Status": "string"
+            }
         },
         "ICON": {
             "selector": "ul.freecompany__focus_icon:nth-child(9) > li:nth-child(5) > div:nth-child(1) > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     }
 }

--- a/linkshell/ls.json
+++ b/linkshell/ls.json
@@ -1,5 +1,6 @@
 {
     "NAME": {
-        "selector": ".heading__linkshell__name"
+        "selector": ".heading__linkshell__name",
+        "type": "string"
     }
 }

--- a/linkshell/members.json
+++ b/linkshell/members.json
@@ -9,43 +9,63 @@
         },
         "AVATAR": {
             "selector": ".entry__chara__face img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "ID": {
             "selector": ".entry__link",
             "attribute": "href",
-            "regex": "/lodestone/character/(?P<ID>\\d*)/"
+            "regex": "/lodestone/character/(?P<ID>\\d*)/",
+            "type": {
+              "ID": "integer"
+            }
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "RANK": {
             "selector": ".entry__chara_info > .js__tooltip",
             "attribute": "data-tooltip",
-            "regex": "/ (?P<RankName>.+)"
+            "regex": "/ (?P<RankName>.+)",
+            "type": {
+              "RankName": "string"
+            }
         },
         "RANK_ICON": {
             "selector": ".entry__chara_info > .js__tooltip > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "LINKSHELL_RANK": {
-            "selector": ".entry__chara_info__linkshell > span"
+            "selector": ".entry__chara_info__linkshell > span",
+            "type": "string"
         },
         "LINKSHELL_RANK_ICON": {
             "selector": ".entry__chara_info__linkshell > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "SERVER": {
             "selector": ".entry__world",
-            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+            "type": {
+              "World": "string",
+              "DC": "string"
+            }
         }
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager:nth-child(5) > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager:nth-child(5) > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "string"
     }
 }

--- a/profile/achievements.json
+++ b/profile/achievements.json
@@ -9,37 +9,57 @@
         },
         "NAME": {
             "selector": ".entry__activity__txt",
-            "regex": "(?P<NameDE>.*) aus der Kategorie „|.*[\\\"「](?P<Name>.*)[\\\"」]"
+            "regex": "(?P<NameDE>.*) aus der Kategorie „|.*[\\\"「](?P<Name>.*)[\\\"」]",
+            "type": {
+              "NameDE": "string",
+              "Name": "string"
+            }
         },
         "ID": {
             "selector": ".entry__achievement",
             "attribute": "href",
-            "regex": "/lodestone/character/\\d*/achievement/detail/(?P<ID>\\d*)/"
+            "regex": "/lodestone/character/\\d*/achievement/detail/(?P<ID>\\d*)/",
+            "type": {
+              "ID": "integer"
+            }
         },
         "TIME": {
             "selector": ".entry__activity__time > script",
-            "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)"
+            "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)",
+            "type": {
+              "Timestamp": "integer"
+            }
         }
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager:nth-child(2) > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager:nth-child(2) > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "string"
     },
     "NO_RESULTS_FOUND": {
         "selector": ".parts__zero"
     },
     "TOTAL_ACHIEVEMENTS": {
         "selector": ".parts__total",
-        "regex": "(?P<TotalAchievements>[0-9]*) \\D+"
+        "regex": "(?P<TotalAchievements>[0-9]*) \\D+",
+        "type": {
+          "TotalAchievements": "integer"
+        }
     },
     "ACHIEVEMENT_POINTS": {
-        "selector": ".achievement__point"
+        "selector": ".achievement__point",
+        "type": "string"
     },
     "ACTIVITY_DESCRIPTION": {
-        "selector": ".entry__activity__txt"
+        "selector": ".entry__activity__txt",
+        "type": "string"
     }
 }

--- a/profile/attributes.json
+++ b/profile/attributes.json
@@ -1,62 +1,82 @@
 {
     "STRENGTH": {
-        "selector": "table.character__param__list:nth-child(2) tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) tr:nth-child(1) > td:nth-child(2)",
+        "type": "integer"
     },
     "DEXTERITY": {
-        "selector": "table.character__param__list:nth-child(2) tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) tr:nth-child(2) > td:nth-child(2)",
+        "type": "integer"
     },
     "VITALITY": {
-        "selector": "table.character__param__list:nth-child(2) tr:nth-child(3) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) tr:nth-child(3) > td:nth-child(2)",
+        "type": "integer"
     },
     "INTELLIGENCE": {
-        "selector": "table.character__param__list:nth-child(2) tr:nth-child(4) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) tr:nth-child(4) > td:nth-child(2)",
+        "type": "integer"
     },
     "MIND": {
-        "selector": "table.character__param__list:nth-child(2) tr:nth-child(5) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) tr:nth-child(5) > td:nth-child(2)",
+        "type": "integer"
     },
     "CRITICAL_HIT_RATE": {
-        "selector": "table.character__param__list:nth-child(4) tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(4) tr:nth-child(1) > td:nth-child(2)",
+        "type": "integer"
     },
     "DETERMINATION": {
-        "selector": "table.character__param__list:nth-child(4) tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(4) tr:nth-child(2) > td:nth-child(2)",
+        "type": "integer"
     },
     "DIRECT_HIT_RATE": {
-        "selector": "table.character__param__list:nth-child(4) tr:nth-child(3) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(4) tr:nth-child(3) > td:nth-child(2)",
+        "type": "integer"
     },
     "DEFENSE": {
-        "selector": "table.character__param__list:nth-child(6) tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(6) tr:nth-child(1) > td:nth-child(2)",
+        "type": "integer"
     },
     "MAGIC_DEFENSE": {
-        "selector": "table.character__param__list:nth-child(6) tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(6) tr:nth-child(2) > td:nth-child(2)",
+        "type": "integer"
     },
     "ATTACK_POWER": {
-        "selector": "table.character__param__list:nth-child(8) tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(8) tr:nth-child(1) > td:nth-child(2)",
+        "type": "integer"
     },
     "SKILL_SPEED": {
-        "selector": "table.character__param__list:nth-child(8) tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(8) tr:nth-child(2) > td:nth-child(2)",
+        "type": "integer"
     },
     "ATTACK_MAGIC_POTENCY": {
-        "selector": "table.character__param__list:nth-child(10) tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(10) tr:nth-child(1) > td:nth-child(2)",
+        "type": "integer"
     },
     "HEALING_MAGIC_POTENCY": {
-        "selector": "table.character__param__list:nth-child(10) tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(10) tr:nth-child(2) > td:nth-child(2)",
+        "type": "integer"
     },
     "SPELL_SPEED": {
-        "selector": "table.character__param__list:nth-child(10) tr:nth-child(3) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(10) tr:nth-child(3) > td:nth-child(2)",
+        "type": "integer"
     },
     "TENACITY": {
-        "selector": "table.character__param__list:nth-child(12) tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(12) tr:nth-child(1) > td:nth-child(2)",
+        "type": "integer"
     },
     "PIETY": {
-        "selector": "table.character__param__list:nth-child(12) tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(12) tr:nth-child(2) > td:nth-child(2)",
+        "type": "integer"
     },
     "HP": {
-        "selector": ".character__param > ul:nth-child(1) > li:nth-child(1) > div:nth-child(1) > span:nth-child(2)"
+        "selector": ".character__param > ul:nth-child(1) > li:nth-child(1) > div:nth-child(1) > span:nth-child(2)",
+        "type": "integer"
     },
     "MP_GP_CP": {
-        "selector": ".character__param > ul:nth-child(1) > li:nth-child(2) > div:nth-child(1) > span:nth-child(2)"
+        "selector": ".character__param > ul:nth-child(1) > li:nth-child(2) > div:nth-child(1) > span:nth-child(2)",
+        "type": "integer"
     },
     "MP_GP_CP_PARAMETER_NAME": {
-        "selector": ".character__param > ul > li:nth-child(2) .character__param__text"
+        "selector": ".character__param > ul > li:nth-child(2) .character__param__text",
+        "type": "string"
     }
 }

--- a/profile/character.json
+++ b/profile/character.json
@@ -1,18 +1,24 @@
 {
     "ACTIVE_CLASSJOB": {
         "selector": ".character__class_icon > img:nth-child(1)",
-        "attribute": "src"
+        "attribute": "src",
+        "type": "string"
     },
     "ACTIVE_CLASSJOB_LEVEL": {
         "selector": ".character__class__data > p:nth-child(1)",
-        "regex": "LEVEL (?P<Level>\\d*)"
+        "regex": "LEVEL (?P<Level>\\d*)",
+        "type": {
+          "Level": "integer"
+        }
     },
     "AVATAR": {
         "selector": ".frame__chara__face > img:nth-child(1)",
-        "attribute": "src"
+        "attribute": "src",
+        "type": "string"
     },
     "BIO": {
-        "selector": ".character__selfintroduction"
+        "selector": ".character__selfintroduction",
+        "type": "string"
     },
     "CLASSJOB_ICONS": {
         "ROOT": {
@@ -21,95 +27,130 @@
         },
         "ICON": {
             "selector": ".js__tooltip",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     },
     "FREE_COMPANY": {
         "ID": {
             "selector": ".character__freecompany__name > h4:nth-child(2) > a:nth-child(1)",
             "attribute": "href",
-            "regex": "/lodestone/freecompany/(?P<ID>.+)/"
+            "regex": "/lodestone/freecompany/(?P<ID>.+)/",
+            "type": {
+              "ID": "integer"
+            }
         },
         "NAME": {
-            "selector": ".character__freecompany__name > h4:nth-child(2) > a:nth-child(1)"
+            "selector": ".character__freecompany__name > h4:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "ICON_LAYERS": {
             "BOTTOM": {
                 "selector": "div.character__freecompany__crest > div > img:nth-child(1)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             },
             "MIDDLE": {
                 "selector": "div.character__freecompany__crest > div > img:nth-child(2)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             },
             "TOP": {
                 "selector": "div.character__freecompany__crest > div > img:nth-child(3)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             }
         }
     },
     "GRAND_COMPANY": {
         "selector": "div.character-block:nth-child(4) > div:nth-child(2) > p:nth-child(2)",
-        "regex": "(?P<Name>\\S*) \/ (?P<Rank>.*)"
+        "regex": "(?P<Name>\\S*) \/ (?P<Rank>.*)",
+        "type": {
+          "Name": "string",
+          "Rank": "sting"
+        }
     },
     "GUARDIAN_DEITY": {
         "NAME": {
-            "selector": "p.character-block__name:nth-child(4)"
+            "selector": "p.character-block__name:nth-child(4)",
+            "type": "string"
         },
         "ICON": {
             "selector": "#character > div.character__content.selected > div.character__profile.clearfix > div.character__profile__data > div:nth-child(1) > div > div:nth-child(2) > img",
-            "attribute": "src"
-        }      
+            "attribute": "src",
+            "type": "string"
+        }
     },
     "NAME": {
-        "selector": "div.frame__chara__box:nth-child(2) > .frame__chara__name"
+        "selector": "div.frame__chara__box:nth-child(2) > .frame__chara__name",
+        "type": "string"
     },
     "NAMEDAY": {
-        "selector": ".character-block__birth"
+        "selector": ".character-block__birth",
+        "type": "string"
     },
     "PORTRAIT": {
         "selector": ".js__image_popup > img:nth-child(1)",
-        "attribute": "src"
+        "attribute": "src",
+        "type": "string"
     },
     "PVP_TEAM": {
         "NAME": {
             "selector": ".character__pvpteam__name > h4:nth-child(2) > a:nth-child(1)",
             "attribute": "href",
-            "regex": "/lodestone/pvpteam/(?P<ID>.+)/"
+            "regex": "/lodestone/pvpteam/(?P<ID>.+)/",
+            "type": {
+              "ID": "integer"
+            }
         },
         "ICON_LAYERS": {
             "BOTTOM": {
                 "selector": ".character__pvpteam__crest__image img:nth-child(1)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             },
             "MIDDLE": {
                 "selector": ".character__pvpteam__crest__image img:nth-child(2)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             },
             "TOP": {
                 "selector": ".character__pvpteam__crest__image img:nth-child(3)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             }
         }
     },
     "RACE_CLAN_GENDER": {
         "selector": "div.character-block:nth-child(1) > div:nth-child(2) > p:nth-child(2)",
-        "regex": "(?P<Race>.*)<br\\/?>(?P<Tribe>.*) \\/ (?P<Gender>.)"
+        "regex": "(?P<Race>.*)<br\\/?>(?P<Tribe>.*) \\/ (?P<Gender>.)",
+        "type": {
+          "Race": "string",
+          "Tribe": "string",
+          "Gender": "string"
+        }
     },
     "SERVER": {
         "selector": "p.frame__chara__world",
-        "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+        "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+        "type": {
+          "World": "string",
+          "DC": "string"
+        }
     },
     "TITLE": {
-        "selector": ".frame__chara__title"
+        "selector": ".frame__chara__title",
+        "type": "string"
     },
     "TOWN": {
         "NAME": {
-            "selector": "div.character-block:nth-child(3) > div:nth-child(2) > p:nth-child(2)"
+            "selector": "div.character-block:nth-child(3) > div:nth-child(2) > p:nth-child(2)",
+            "type": "string"
         },
         "ICON": {
             "selector": "#character > div.character__content.selected > div.character__profile.clearfix > div.character__profile__data > div:nth-child(1) > div > div:nth-child(3) > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     }
 }

--- a/profile/classjob.json
+++ b/profile/classjob.json
@@ -1,422 +1,631 @@
 {
     "BOZJA": {
         "LEVEL": {
-            "selector": "div.character__job__list:nth-child(7) > div:nth-child(2)"
+            "selector": "div.character__job__list:nth-child(7) > div:nth-child(2)",
+            "type": "integer"
         },
         "METTLE": {
             "selector": "div.character__job__list:nth-child(7) > div:nth-child(4)",
-            "regex": "(?P<Mettle>\\S+) \\/"
+            "regex": "(?P<Mettle>\\S+) \\/",
+            "type": {
+              "Mettle": "string"
+            }
         },
         "NAME": {
-            "selector": "div.character__job__list:nth-child(7) > div:nth-child(3)"
+            "selector": "div.character__job__list:nth-child(7) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "EUREKA": {
         "EXP": {
             "selector": "div.character__job__list:nth-child(9) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         },
         "LEVEL": {
-            "selector": "div.character__job__list:nth-child(9) > div:nth-child(2)"
+            "selector": "div.character__job__list:nth-child(9) > div:nth-child(2)",
+            "type": "integer"
         },
         "NAME": {
-            "selector": "div.character__job__list:nth-child(9) > div:nth-child(3)"
+            "selector": "div.character__job__list:nth-child(9) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "PALADIN": {
         "LEVEL": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "WARRIOR": {
         "LEVEL": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "DARKKNIGHT": {
         "LEVEL": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "GUNBREAKER": {
         "LEVEL": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(2)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(3)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": ".character__content > div:nth-child(2) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "WHITEMAGE": {
         "LEVEL": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "SCHOLAR": {
         "LEVEL": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "ASTROLOGIAN": {
         "LEVEL": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "SAGE": {
         "LEVEL": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(2)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(3)"
+            "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": ".character__content > div:nth-child(2) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "MONK": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "DRAGOON": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "NINJA": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "SAMURAI": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "REAPER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "VIPER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "BARD": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "MACHINIST": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "DANCER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(3) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "BLACKMAGE": {
         "LEVEL": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(1) > div:nth-child(2)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(1) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(1) > div:nth-child(3)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "ul.character__job:nth-child(4) > li:nth-child(1) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "SUMMONER": {
         "LEVEL": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(2) > div:nth-child(2)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(2) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(2) > div:nth-child(3)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(2) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "ul.character__job:nth-child(4) > li:nth-child(2) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "REDMAGE": {
         "LEVEL": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(3) > div:nth-child(2)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(3) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(3) > div:nth-child(3)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(3) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "ul.character__job:nth-child(4) > li:nth-child(3) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "PICTOMANCER": {
         "LEVEL": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(4) > div:nth-child(2)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(4) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(4) > div:nth-child(3)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(4) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "ul.character__job:nth-child(4) > li:nth-child(4) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "BLUEMAGE": {
         "LEVEL": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(5) > div:nth-child(2)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(5) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "ul.character__job:nth-child(4) > li:nth-child(5) > div:nth-child(3)"
+            "selector": "ul.character__job:nth-child(4) > li:nth-child(5) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "ul.character__job:nth-child(4) > li:nth-child(5) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "CARPENTER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "BLACKSMITH": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "ARMORER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "GOLDSMITH": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(4) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "LEATHERWORKER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(5) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "WEAVER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(6) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "ALCHEMIST": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(7) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(7) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(7) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(7) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(7) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "CULINARIAN": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(8) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(8) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(8) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(8) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(1) > ul:nth-child(2) > li:nth-child(8) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "MINER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(1) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "BOTANIST": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     },
     "FISHER": {
         "LEVEL": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(2)",
+            "type": "integer"
         },
         "UNLOCKSTATE": {
-            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)"
+            "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(3)",
+            "type": "string"
         },
         "EXP": {
             "selector": "div.clearfix:nth-child(5) > div:nth-child(2) > ul:nth-child(2) > li:nth-child(3) > div:nth-child(4)",
-            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)"
+            "regex": "(?P<CurrentEXP>\\S+) \\/ (?P<MaxEXP>\\S+)",
+            "type": {
+              "CurrentEXP": "integer",
+              "MaxEXP": "integer"
+            }
         }
     }
 }

--- a/profile/gearset.json
+++ b/profile/gearset.json
@@ -1,611 +1,913 @@
 {
     "MAINHAND": {
         "NAME": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--0 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--0 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--0 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "OFFHAND": {
         "NAME": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--1 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--1 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--1 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "HEAD": {
         "NAME": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--2 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--2 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--2 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "BODY": {
         "NAME": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--3 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--3 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--3 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "HANDS": {
         "NAME": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--4 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--4 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--4 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "WAIST": {
         "NAME": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--5 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--5 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--5 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "LEGS": {
         "NAME": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--6 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--6 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--6 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "FEET": {
         "NAME": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--7 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--7 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--7 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "EARRINGS": {
         "NAME": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--8 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--8 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "NECKLACE": {
         "NAME": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--9 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--9 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--9 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "BRACELETS": {
         "NAME": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--10 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--10 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--10 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "RING1": {
         "NAME": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--11 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--11 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--11 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "RING2": {
         "NAME": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "DB_LINK": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "MIRAGE_NAME": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)"
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2)",
+            "type": "string"
         },
         "MIRAGE_DB_LINK": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)"
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(3) > p:nth-child(2) > a:nth-child(1)",
+            "type": "string"
         },
         "STAIN": {
-            "selector": ".icon-c--12 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--12 > div:nth-child(4) > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(3) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "MATERIA_1": {
             "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(1) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_2": {
             "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(2) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_3": {
             "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(3) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_4": {
             "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(4) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "MATERIA_5": {
             "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > ul:nth-of-type(2) > li:nth-child(5) > div:nth-child(2)",
-            "regex": "(?P<Name>.*)<br/>"
+            "regex": "(?P<Name>.*)<br/>",
+            "type": {
+              "Name": "string"
+            }
         },
         "CREATOR_NAME": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)"
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(7) > div:nth-child(1) > a:nth-child(1)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--12 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     },
     "SOULCRYSTAL": {
         "NAME": {
-            "selector": ".icon-c--13 > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)"
+            "selector": ".icon-c--13 > div:nth-child(3) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
         },
         "CLASS_LIST": {
-            "selector": ".icon-c--13 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)"
+            "selector": ".icon-c--13 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(5) > div:nth-child(1) > div:nth-child(1)",
+            "type": "string"
         },
         "ITEM_LEVEL": {
-            "selector": ".icon-c--13 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)"
+            "selector": ".icon-c--13 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(3)",
+            "type": "string"
         }
     }
 }

--- a/profile/minion.json
+++ b/profile/minion.json
@@ -5,14 +5,17 @@
             "multiple": true
         },
         "NAME": {
-            "selector": ".minion__name"
+            "selector": ".minion__name",
+            "type": "string"
         },
         "ICON": {
             "selector": ".minion__list__icon__image",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     },
     "TOTAL": {
-        "selector": ".minion__sort__total > span:nth-child(1)"
+        "selector": ".minion__sort__total > span:nth-child(1)",
+        "type": "integer"
     }
 }

--- a/profile/mount.json
+++ b/profile/mount.json
@@ -5,14 +5,17 @@
             "multiple": true
         },
         "NAME": {
-            "selector": ".mount__name"
+            "selector": ".mount__name",
+            "type": "string"
         },
         "ICON": {
             "selector": ".mount__list__icon__image",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     },
     "TOTAL": {
-        "selector": ".minion__sort__total > span:nth-child(1)"
+        "selector": ".minion__sort__total > span:nth-child(1)",
+        "type": "integer"
     }
 }

--- a/pvpteam/members.json
+++ b/pvpteam/members.json
@@ -9,7 +9,8 @@
         },
         "AVATAR": {
             "selector": ".entry__chara__face img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "ID": {
             "selector": ".entry__bg",
@@ -17,23 +18,33 @@
             "regex": "/lodestone/character/(?P<ID>\\d*)/"
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "MATCHES": {
-            "selector": ".entry__freecompany__info > li:last-of-type > span"
+            "selector": ".entry__freecompany__info > li:last-of-type > span",
+            "type": "integer"
         },
         "RANK": {
             "selector": ".entry__freecompany__info > .js__tooltip",
             "attribute": "data-tooltip",
-            "regex": "/ (?P<RankName>.+)"
+            "regex": "/ (?P<RankName>.+)",
+            "type": {
+              "RankName": "string"
+            }
         },
         "RANK_ICON": {
             "selector": ".entry__freecompany__info > .js__tooltip > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "SERVER": {
             "selector": ".entry__world",
-            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+            "type": {
+              "World": "string",
+              "DC": "string"
+            }
         }
     }
 }

--- a/pvpteam/pvpteam.json
+++ b/pvpteam/pvpteam.json
@@ -1,26 +1,34 @@
 {
     "NAME": {
-        "selector": ".entry__pvpteam__name--team"
+        "selector": ".entry__pvpteam__name--team",
+        "type": "string"
     },
     "DC": {
-        "selector": ".entry__pvpteam__name--dc"
+        "selector": ".entry__pvpteam__name--dc",
+        "type": "string"
     },
     "FORMED": {
         "selector": ".entry__pvpteam__data--formed > script",
-        "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)"
+        "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)",
+        "type": {
+          "Timestamp": "integer"
+        }
     },
     "CREST_LAYERS": {
         "BOTTOM": {
             "selector": ".entry__pvpteam__crest__image > img:nth-child(1)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "MIDDLE": {
             "selector": ".entry__pvpteam__crest__image > img:nth-child(2)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "TOP": {
             "selector": ".entry__pvpteam__crest__image > img:nth-child(3)",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         }
     }
 }

--- a/search/character.json
+++ b/search/character.json
@@ -9,40 +9,59 @@
         },
         "AVATAR": {
             "selector": ".entry__chara__face > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "ID": {
             "selector": ".entry__link",
             "attribute": "href",
-            "regex": "/lodestone/character/(?P<ID>\\d*)/"
+            "regex": "/lodestone/character/(?P<ID>\\d*)/",
+            "time": {
+              "ID": "integer"
+            }
         },
         "LANG": {
-            "selector": ".entry__chara__lang"
+            "selector": ".entry__chara__lang",
+            "type": "string"
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "RANK": {
             "selector": ".entry__chara_info > .js__tooltip",
             "attribute": "data-tooltip",
-            "regex": "/ (?P<RankName>.+)"
+            "regex": "/ (?P<RankName>.+)",
+            "type": {
+              "RankName": "string"
+            }
         },
         "RANK_ICON": {
             "selector": ".entry__chara_info > .js__tooltip > img",
-            "attribute": "src"
+            "attribute": "src",
+            "type": "string"
         },
         "SERVER": {
             "selector": ".entry__world",
-            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+            "type": {
+              "World": "string",
+              "DC": "string"
+            }
         }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "string"
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "NO_RESULTS_FOUND": {
         "selector": ".parts__zero"

--- a/search/cwls.json
+++ b/search/cwls.json
@@ -10,27 +10,39 @@
         "ID": {
             "selector": ".entry__link--line",
             "attribute": "href",
-            "regex": "/lodestone/crossworld_linkshell/(?P<ID>\\w*)/"
+            "regex": "/lodestone/crossworld_linkshell/(?P<ID>\\w*)/",
+            "type": {
+              "ID": "integer"
+            }
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "DC": {
-            "selector": ".entry__world"
+            "selector": ".entry__world",
+            "type": "string"
         },
         "ACTIVE_MEMBERS": {
-            "selector": ".entry__linkshell__member > div > span"
+            "selector": ".entry__linkshell__member > div > span",
+            "type": "integer"
         }
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager:nth-child(6) > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "string"
     },
     "NO_RESULTS_FOUND": {
-        "selector": ".parts__zero"
+        "selector": ".parts__zero",
+        "type": "string"
     }
 }

--- a/search/freecompany.json
+++ b/search/freecompany.json
@@ -10,60 +10,87 @@
         "CREST_LAYERS": {
             "BOTTOM": {
                 "selector": ".entry__freecompany__crest__image > img:nth-child(1)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             },
             "MIDDLE": {
                 "selector": ".entry__freecompany__crest__image > img:nth-child(2)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             },
             "TOP": {
                 "selector": ".entry__freecompany__crest__image > img:nth-child(3)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             }
         },
         "ID": {
             "selector": ".entry__block",
             "attribute": "href",
-            "regex": "/lodestone/freecompany/(?P<ID>\\d*)/"
+            "regex": "/lodestone/freecompany/(?P<ID>\\d*)/",
+            "type": {
+              "ID": "integer"
+            }
         },
         "GRAND_COMPANY": {
-            "selector": ".entry__world:nth-child(1)"
+            "selector": ".entry__world:nth-child(1)",
+            "type": "string"
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "SERVER": {
             "selector": ".entry__world:nth-child(3)",
-            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+            "type": {
+              "World": "string",
+              "DC": "string"
+            }
         },
         "ACTIVE": {
             "selector": "li.entry__freecompany__fc-active:nth-child(4)",
-            "regex": "Active:\\s+(?P<State>\\w*)"
+            "regex": "Active:\\s+(?P<State>\\w*)",
+            "type": "string"
         },
         "ACTIVE_MEMBERS": {
-            "selector": ".entry__freecompany__fc-member"
+            "selector": ".entry__freecompany__fc-member",
+            "type": "integer"
         },
         "RECRUITMENT_OPEN": {
             "selector": "li.entry__freecompany__fc-active:nth-child(5)",
-            "regex": "Recruitment:\\s+(?P<State>\\w*)"
+            "regex": "Recruitment:\\s+(?P<State>\\w*)",
+            "type": {
+              "State": "string"
+            }
         },
         "ESTATE_BUILT": {
-            "selector": ".entry__freecompany__fc-housing"
+            "selector": ".entry__freecompany__fc-housing",
+            "type": "string"
         },
         "FORMED": {
             "selector": ".entry__freecompany__fc-day > script",
-            "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)"
+            "regex": ".*ldst_strftime\\((?P<Timestamp>\\d*)",
+            "types": {
+              "Timestamp": "integer"
+            }
         }
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager:nth-child(6) > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "string"
     },
     "NO_RESULTS_FOUND": {
-        "selector": ".parts__zero"
+        "selector": ".parts__zero",
+        "type": "boolean"
     }
 }

--- a/search/linkshell.json
+++ b/search/linkshell.json
@@ -10,28 +10,43 @@
         "ID": {
             "selector": ".entry__link--line",
             "attribute": "href",
-            "regex": "/lodestone/linkshell/(?P<ID>\\d*)/"
+            "regex": "/lodestone/linkshell/(?P<ID>\\d*)/",
+            "type": {
+              "ID": "integer"
+            }
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "SERVER": {
             "selector": ".entry__world",
-            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]"
+            "regex": "(?P<World>\\w*)\\s+\\[(?P<DC>\\w*)\\]",
+            "type": {
+              "World": "string",
+              "DC": "string"
+            }
         },
         "ACTIVE_MEMBERS": {
-            "selector": ".entry__linkshell__member > div > span"
+            "selector": ".entry__linkshell__member > div > span",
+            "type": "integer"
         }
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager:nth-child(6) > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "string"
     },
     "NO_RESULTS_FOUND": {
-        "selector": ".parts__zero"
+        "selector": ".parts__zero",
+        "type": "boolean"
     }
 }

--- a/search/pvpteam.json
+++ b/search/pvpteam.json
@@ -10,15 +10,18 @@
         "CREST_LAYERS": {
             "BOTTOM": {
                 "selector": ".entry__pvpteam__search__crest__image > img:nth-child(1)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             },
             "MIDDLE": {
                 "selector": ".entry__pvpteam__search__crest__image > img:nth-child(2)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             },
             "TOP": {
                 "selector": ".entry__pvpteam__search__crest__image > img:nth-child(3)",
-                "attribute": "src"
+                "attribute": "src",
+                "type": "string"
             }
         },
         "ID": {
@@ -27,21 +30,29 @@
             "regex": "/lodestone/pvpteam/(?P<ID>\\w*)/"
         },
         "NAME": {
-            "selector": ".entry__name"
+            "selector": ".entry__name",
+            "type": "string"
         },
         "DC": {
-            "selector": ".entry__world"
+            "selector": ".entry__world",
+            "type": "string"
         }
     },
     "PAGE_INFO": {
         "selector": "ul.btn__pager:nth-child(6) > li:nth-child(3)",
-        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)"
+        "regex": "\\D*(?P<CurrentPage>\\d+)\\D*(?P<NumPages>\\d+)",
+        "type": {
+          "CurrentPage": "integer",
+          "NumPages": "integer"
+        }
     },
     "LIST_NEXT_BUTTON": {
         "selector": "ul.btn__pager > li:nth-child(4) > a:nth-child(1)",
-        "attribute": "href"
+        "attribute": "href",
+        "type": "string"
     },
     "NO_RESULTS_FOUND": {
-        "selector": ".parts__zero"
+        "selector": ".parts__zero",
+        "type": "boolean"
     }
 }


### PR DESCRIPTION
### Feature: adding types to fields

Per our discussion, this adds types to pretty much every field, but with a few caveats worth discussion:

* Anything that counts as a field has a new `type` field, which follows one of two forms:

```json
{
    "type": "$TYPE"
}
```

or

```json
{
    "type": {
        "FieldName": "$TYPE",
        "OtherField": "$TYPE"
    }
}
```

In the former form, the type is just `$TYPE`; the latter form (used in regexes where there's defined capture groups) maps each defined name to a `$TYPE`.

The list of type(s) implemented at current:

* integer - numerical number, usually non-decimal; if there's a parsing issue, assume a "default" of 0
* string - string form; if there's a parsing issue, assume an empty string
* boolean - true/false value; if there's a value, assume `true`, otherwise assume `false`

### Extra discussion (that will make me sad because there's more edits if so)

* Should we add more types
* Should we change the expectations of the types other than what I documented above
* Should we change the format
* Should we assume "implicit string if none defined"
* Should there now be "docs" explaining what the schema looks like and why?