### PR TITLE
Add Facewear to gearset.json

### DIFF
--- a/profile/gearset.json
+++ b/profile/gearset.json
@@ -556,6 +556,10 @@
             "selector": ".icon-c--glasses > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
             "type": "string"
         },
+        "UNLOCKED_BY": {
+            "selector": ".icon-c--glasses > .db-tooltip > div:nth-child(1) > div:nth-child(2) > a:nth-child(2)",
+            "type": "string"
+        },
         "DB_LINK": {
             "selector": ".icon-c--glasses > .db-tooltip > div:nth-child(1) > div:nth-child(2) > a:nth-child(2)",
             "type": "string"

--- a/profile/gearset.json
+++ b/profile/gearset.json
@@ -551,6 +551,16 @@
             "type": "string"
         }
     },
+    "FACEWEAR": {
+        "NAME": {
+            "selector": ".icon-c--glasses > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",
+            "type": "string"
+        },
+        "DB_LINK": {
+            "selector": ".icon-c--glasses > .db-tooltip > div:nth-child(1) > div:nth-child(2) > a:nth-child(2)",
+            "type": "string"
+        }
+    },
     "EARRINGS": {
         "NAME": {
             "selector": ".icon-c--8 > .db-tooltip > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > h2:nth-child(2)",


### PR DESCRIPTION
Add support for parsing facewear from the Lodestone. The popup when hovering facewear is quite different from other gear pieces. It only shows the name of the facewear and its icon, and the icon and DB link for the item that unlocks it.

I've decided to use the name of the facewear itself for the CSS selector (not the name of the item that unlocks it). The DB link points towards the item that unlocks the facewear.